### PR TITLE
[bugfix] Fixes median cut frequencies not summing to one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# Unreleased
+
+
+
+# Released
+
+## [3.0.1] 07/07/2024
+
+### Fixed
+- Fixed a bug where the color frequencies of colors in a palette were not summing to one when using the Median Cut algorithm.
 
 ## [3.0.0] 02/07/2024
 
@@ -15,10 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - An URL to an image file, as a string.
   - A byte stream of an image file, as a bytes object.
   - A numpy array of an image file, as a numpy array.
-
-
-# Released
-
+  -
 ## [2.3.0] 19/06/2024
 
 - Added `image_array` to the `extract_color` function, allowing the user to specify an image as a numpy array.

--- a/Pylette/src/color_extraction.py
+++ b/Pylette/src/color_extraction.py
@@ -41,7 +41,6 @@ def median_cut_extraction(arr: np.ndarray, height: int, width: int, palette_size
 
     arr = arr.reshape((width * height, -1))
     c = [ColorBox(arr)]
-    full_box_size = c[0].size
 
     # Each iteration, find the largest box, split it, remove original box from list of boxes, and add the two new boxes.
     while len(c) < palette_size:
@@ -49,7 +48,8 @@ def median_cut_extraction(arr: np.ndarray, height: int, width: int, palette_size
         # add the two new boxes to the list, while removing the split box.
         c = c[:largest_c_idx] + c[largest_c_idx].split() + c[largest_c_idx + 1 :]
 
-    colors = [Color(tuple(map(int, box.average)), box.size / full_box_size) for box in c]
+    total_pixels = width * height
+    colors = [Color(tuple(map(int, box.average)), box.pixel_count / total_pixels) for box in c]
 
     return colors
 

--- a/Pylette/src/utils.py
+++ b/Pylette/src/utils.py
@@ -98,3 +98,13 @@ class ColorBox:
             ColorBox(self.colors[:median_index]),
             ColorBox(self.colors[median_index:]),
         ]
+
+    @property
+    def pixel_count(self) -> int:
+        """
+        Returns the number of pixels in the ColorBox.
+
+        Returns:
+            int: The number of pixels in the ColorBox.
+        """
+        return len(self.colors)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pylette"
-version = "3.0.0"
+version = "3.0.1"
 description = "A Python library for extracting color palettes from images."
 authors = ["Ivar Stangeby"]
 license = "MIT"
@@ -42,6 +42,7 @@ requests-mock = "^1.12.1"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
 
 
 

--- a/tests/integration/test_colorspaces.py
+++ b/tests/integration/test_colorspaces.py
@@ -53,13 +53,7 @@ def test_kmean_extracted_palette(test_image_path_as_str):
 @pytest.mark.parametrize("palette_size", [1, 5, 10, 100])
 @pytest.mark.parametrize(
     "extraction_mode",
-    [
-        "KM",
-        pytest.param(
-            "MC",
-            marks=pytest.mark.skip("Currently a bug in the MC algorithm, causing frequencies not summing to one"),
-        ),
-    ],
+    ["KM", "MC"],
 )
 def test_palette_invariants_with_image_path(test_image_path_as_str, palette_size, extraction_mode):
     palette = extract_colors(
@@ -92,13 +86,7 @@ def test_palette_invariants_with_image_path(test_image_path_as_str, palette_size
 @pytest.mark.parametrize("palette_size", [1, 5, 10, 100])
 @pytest.mark.parametrize(
     "extraction_mode",
-    [
-        "KM",
-        pytest.param(
-            "MC",
-            marks=pytest.mark.skip("Currently a bug in the MC algorithm, causing frequencies not summing to one"),
-        ),
-    ],
+    ["KM", "MC"],
 )
 def test_palette_invariants_with_image_pathlike(test_image_path_as_pathlike, palette_size, extraction_mode):
     palette = extract_colors(
@@ -131,13 +119,7 @@ def test_palette_invariants_with_image_pathlike(test_image_path_as_pathlike, pal
 @pytest.mark.parametrize("palette_size", [1, 5, 10, 100])
 @pytest.mark.parametrize(
     "extraction_mode",
-    [
-        "KM",
-        pytest.param(
-            "MC",
-            marks=pytest.mark.skip("Currently a bug in the MC algorithm, causing frequencies not summing to one"),
-        ),
-    ],
+    ["KM", "MC"],
 )
 def test_palette_invariants_with_image_bytes(test_image_as_bytes, palette_size, extraction_mode):
     palette = extract_colors(
@@ -170,13 +152,7 @@ def test_palette_invariants_with_image_bytes(test_image_as_bytes, palette_size, 
 @pytest.mark.parametrize("palette_size", [1, 5, 10, 100])
 @pytest.mark.parametrize(
     "extraction_mode",
-    [
-        "KM",
-        pytest.param(
-            "MC",
-            marks=pytest.mark.skip("Currently a bug in the MC algorithm, causing frequencies not summing to one"),
-        ),
-    ],
+    ["KM", "MC"],
 )
 def test_palette_invariants_with_opencv(test_image_from_opencv, palette_size, extraction_mode):
     palette = extract_colors(
@@ -209,13 +185,7 @@ def test_palette_invariants_with_opencv(test_image_from_opencv, palette_size, ex
 @pytest.mark.parametrize("palette_size", [1, 5, 10, 100])
 @pytest.mark.parametrize(
     "extraction_mode",
-    [
-        "KM",
-        pytest.param(
-            "MC",
-            marks=pytest.mark.skip("Currently a bug in the MC algorithm, causing frequencies not summing to one"),
-        ),
-    ],
+    ["KM", "MC"],
 )
 def test_palette_invariants_with_image_url(test_image_as_url, palette_size, extraction_mode):
     palette = extract_colors(


### PR DESCRIPTION
When computing the frequency of the extracted color in the `median_cut` algorithm, I was incorrectly using the volume of the color-box instead of the number of pixels as the determining factor. 

Solved by dividing the number of pixels in the color box by the total number of pixels (width * height of the image). 