### PR TITLE
[fix] Pass on colorspace argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Released
 
+## [3.0.2] 04/10/2024
+
+### Fixed
+
+- Fixed a bug where the CLI did not respect the `--colorspace` argument when extracting colors.
 ## [3.0.1] 07/07/2024
 
 ### Fixed

--- a/Pylette/cmd.py
+++ b/Pylette/cmd.py
@@ -34,7 +34,7 @@ def main():
     parser.add_argument(
         "--colorspace",
         help="color space to represent colors in",
-        default="RGB",
+        default="rgb",
         type=str,
         choices=["rgb", "hsv", "hls"],
     )
@@ -59,7 +59,7 @@ def main():
         image = args.image_url
 
     palette = extract_colors(image=image, palette_size=args.n, sort_mode=args.sort_by)
-    palette.to_csv(filename=args.out_filename, frequency=True, stdout=args.stdout)
+    palette.to_csv(filename=args.out_filename, frequency=True, stdout=args.stdout, colorspace=args.colorspace)
     if args.display_colors:
         palette.display()
 

--- a/Pylette/src/color.py
+++ b/Pylette/src/color.py
@@ -55,7 +55,6 @@ class Color(object):
             tuple[int, ...] | tuple[float, ...]: The color values in the specified color space.
         """
         colors = {"rgb": self.rgb, "hsv": self.hsv, "hls": self.hls}
-
         return colors[colorspace]
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pylette"
-version = "3.0.1"
+version = "3.0.2"
 description = "A Python library for extracting color palettes from images."
 authors = ["Ivar Stangeby"]
 license = "MIT"
@@ -42,6 +42,7 @@ requests-mock = "^1.12.1"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
 
 
 


### PR DESCRIPTION
It was reported in #40 that the CLI does not respect the colorspace argument passed on the command line.

This PR fixes that. 