### PR TITLE
ci: add dependabot file

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
[I’m using](https://github.com/gaelgoth/snapmetrics) your project as a dependency and noticed that some of its dependencies are bit outdated. To help keep the project up to date, I’ve configured Dependabot to manage updates for some of them.

On my fork, this setup has [opened 10 pull requests](https://github.com/gaelgoth/Pylette/pulls) addressing updates to GitHub Actions and Python dependencies. All of these changes successfully passed the GitHub Actions workflows in my fork, which suggests that the updates are working as expected 👍🏾 