### PR TITLE
Implement KMeans and MedianCut extractors in terms of the extractor base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Released
 
+## 4.0.1 27/01/2025
+
+### Added
+
+- A `ColorExtractor`-protocol that defines an interface for color extractors.
+- Create a `ColorExtractorBase` abstract class that extractors can inherit from to implement the interface.
+
+### Changed
+- The implementation of `median_cut_extraction` and `k_means_extraction` is now
+implemented as in terms of subclasses of the `ColorExtractorBase`
+
 ## [4.0.0] 08/10/2024
 
 ### Changed

--- a/Pylette/src/extractors/k_means.py
+++ b/Pylette/src/extractors/k_means.py
@@ -1,11 +1,38 @@
 import numpy as np
 from numpy.typing import NDArray
-from sklearn import KMeans
+from sklearn.cluster import KMeans
 
 from Pylette.src.color import Color
+from Pylette.src.extractors.protocol import NP_T, ColorExtractorBase
 
 
-def k_means_extraction(arr: NDArray[float], height: int, width: int, palette_size: int) -> list[Color]:
+class KMeansExtractor(ColorExtractorBase):
+    def extract(self, arr: NDArray[NP_T], height: int, width: int, palette_size: int) -> list[Color]:
+        """
+        Extracts a color palette using KMeans.
+
+        Parameters:
+            arr (NDArray[float]): The input array.
+            height (int): The height of the image.
+            width (int): The width of the image.
+            palette_size (int): The number of colors to extract from the image.
+
+        Returns:
+            list[Color]: A palette of colors sorted by frequency.
+        """
+        arr = np.reshape(arr, (width * height, -1))
+        model = KMeans(n_clusters=palette_size, n_init="auto", init="k-means++", random_state=2024)
+        labels = model.fit_predict(arr)
+        palette = np.array(model.cluster_centers_, dtype=int)
+        color_count = np.bincount(labels)
+        color_frequency = color_count / float(np.sum(color_count))
+        colors = []
+        for color, freq in zip(palette, color_frequency):
+            colors.append(Color(color, freq))
+        return colors
+
+
+def k_means_extraction(arr: NDArray[NP_T], height: int, width: int, palette_size: int) -> list[Color]:
     """
     Extracts a color palette using KMeans.
 
@@ -18,13 +45,4 @@ def k_means_extraction(arr: NDArray[float], height: int, width: int, palette_siz
     Returns:
         list[Color]: A palette of colors sorted by frequency.
     """
-    arr = np.reshape(arr, (width * height, -1))
-    model = KMeans(n_clusters=palette_size, n_init="auto", init="k-means++", random_state=2024)
-    labels = model.fit_predict(arr)
-    palette = np.array(model.cluster_centers_, dtype=int)
-    color_count = np.bincount(labels)
-    color_frequency = color_count / float(np.sum(color_count))
-    colors = []
-    for color, freq in zip(palette, color_frequency):
-        colors.append(Color(color, freq))
-    return colors
+    return KMeansExtractor().extract(arr=arr, height=height, width=width, palette_size=palette_size)

--- a/Pylette/src/extractors/k_means.py
+++ b/Pylette/src/extractors/k_means.py
@@ -1,0 +1,30 @@
+import numpy as np
+from numpy.typing import NDArray
+from sklearn import KMeans
+
+from Pylette.src.color import Color
+
+
+def k_means_extraction(arr: NDArray[float], height: int, width: int, palette_size: int) -> list[Color]:
+    """
+    Extracts a color palette using KMeans.
+
+    Parameters:
+        arr (NDArray[float]): The input array.
+        height (int): The height of the image.
+        width (int): The width of the image.
+        palette_size (int): The number of colors to extract from the image.
+
+    Returns:
+        list[Color]: A palette of colors sorted by frequency.
+    """
+    arr = np.reshape(arr, (width * height, -1))
+    model = KMeans(n_clusters=palette_size, n_init="auto", init="k-means++", random_state=2024)
+    labels = model.fit_predict(arr)
+    palette = np.array(model.cluster_centers_, dtype=int)
+    color_count = np.bincount(labels)
+    color_frequency = color_count / float(np.sum(color_count))
+    colors = []
+    for color, freq in zip(palette, color_frequency):
+        colors.append(Color(color, freq))
+    return colors

--- a/Pylette/src/extractors/median_cut.py
+++ b/Pylette/src/extractors/median_cut.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+from Pylette.src.color import Color
+from Pylette.src.utils import ColorBox
+
+
+def median_cut_extraction(arr: np.ndarray, height: int, width: int, palette_size: int) -> list[Color]:
+    """
+    Extracts a color palette using the median cut algorithm.
+
+    Parameters:
+        arr (np.ndarray): The input array.
+        height (int): The height of the image.
+        width (int): The width of the image.
+        palette_size (int): The number of colors to extract from the image.
+
+    Returns:
+        list[Color]: A list of colors extracted from the image.
+    """
+
+    arr = arr.reshape((width * height, -1))
+    c = [ColorBox(arr)]
+
+    # Each iteration, find the largest box, split it, remove original box from list of boxes, and add the two new boxes.
+    while len(c) < palette_size:
+        largest_c_idx = np.argmax(c)
+        # add the two new boxes to the list, while removing the split box.
+        c = c[:largest_c_idx] + c[largest_c_idx].split() + c[largest_c_idx + 1 :]
+
+    total_pixels = width * height
+    colors = [Color(tuple(map(int, box.average)), box.pixel_count / total_pixels) for box in c]
+
+    return colors

--- a/Pylette/src/extractors/median_cut.py
+++ b/Pylette/src/extractors/median_cut.py
@@ -1,7 +1,35 @@
 import numpy as np
+from numpy.typing import NDArray
 
 from Pylette.src.color import Color
+from Pylette.src.extractors.protocol import NP_T, ColorExtractorBase
 from Pylette.src.utils import ColorBox
+
+
+class MedianCutExtractor(ColorExtractorBase):
+    def extract(self, arr: NDArray[NP_T], height: int, width: int, palette_size: int) -> list[Color]:
+        """
+        Extracts a color palette using the median cut algorithm.
+
+        Parameters:
+            arr (np.ndarray): The input array.
+            height (int): The height of the image.
+            width (int): The width of the image.
+            palette_size (int): The number of colors to extract from the image.
+
+        Returns:
+            list[Color]: A list of colors extracted from the image.
+        """
+
+        arr = self._reshape_array(arr=arr, height=height, width=width)
+
+        boxes = [ColorBox(arr)]
+        while len(boxes) < palette_size:
+            largest_box_idx = np.argmax(boxes)  # type: ignore
+            boxes = boxes[:largest_box_idx] + boxes[largest_box_idx].split() + boxes[largest_box_idx + 1 :]
+
+        total_pixels = width * height
+        return [Color(tuple(map(int, box.average)), box.pixel_count / total_pixels) for box in boxes]
 
 
 def median_cut_extraction(arr: np.ndarray, height: int, width: int, palette_size: int) -> list[Color]:
@@ -18,16 +46,4 @@ def median_cut_extraction(arr: np.ndarray, height: int, width: int, palette_size
         list[Color]: A list of colors extracted from the image.
     """
 
-    arr = arr.reshape((width * height, -1))
-    c = [ColorBox(arr)]
-
-    # Each iteration, find the largest box, split it, remove original box from list of boxes, and add the two new boxes.
-    while len(c) < palette_size:
-        largest_c_idx = np.argmax(c)
-        # add the two new boxes to the list, while removing the split box.
-        c = c[:largest_c_idx] + c[largest_c_idx].split() + c[largest_c_idx + 1 :]
-
-    total_pixels = width * height
-    colors = [Color(tuple(map(int, box.average)), box.pixel_count / total_pixels) for box in c]
-
-    return colors
+    return MedianCutExtractor().extract(arr, height, width, palette_size)

--- a/Pylette/src/extractors/protocol.py
+++ b/Pylette/src/extractors/protocol.py
@@ -1,0 +1,22 @@
+from abc import ABC, abstractmethod
+from typing import Protocol, TypeVar
+
+import numpy as np
+from numpy.typing import NDArray
+
+from Pylette.src.color import Color
+
+NP_T = TypeVar("NP_T", bound=np.generic, covariant=True)
+
+
+class ColorExtractor(Protocol):
+    def extract(self, arr: NDArray[NP_T], height: int, width: int, palette_size: int) -> list[Color]: ...
+
+
+class ColorExtractorBase(ABC):
+    @abstractmethod
+    def extract(self, arr: NDArray[NP_T], height: int, width: int, palette_size: int) -> list[Color]:
+        pass
+
+    def _reshape_array(self, arr: NDArray[NP_T], height: int, width: int) -> NDArray[NP_T]:
+        return arr.reshape((height * width, -1))

--- a/Pylette/src/utils.py
+++ b/Pylette/src/utils.py
@@ -23,8 +23,8 @@ class ColorBox:
         """
         Calculates the minimum and maximum values for each color channel in the ColorBox.
         """
-        self.min_channel: NDArray[np.uint8, (3,)] = np.min(self.colors, axis=0)
-        self.max_channel: NDArray[np.uint8, (3,)] = np.max(self.colors, axis=0)
+        self.min_channel: NDArray[np.uint8] = np.min(self.colors, axis=0)
+        self.max_channel: NDArray[np.uint8] = np.max(self.colors, axis=0)
 
     def __lt__(self, other: "ColorBox") -> bool:
         """
@@ -36,10 +36,10 @@ class ColorBox:
         Returns:
         bool: True if the volume of this ColorBox is less than the volume of the other ColorBox, False otherwise.
         """
-        return self.size < other.size
+        return bool(self.size < other.size)
 
     @property
-    def size(self) -> np.uint64:
+    def size(self) -> int:
         """
         Returns the volume of the ColorBox.
 
@@ -55,12 +55,12 @@ class ColorBox:
         Returns:
             int: The index of the dominant color channel.
         """
-        diff: NDArray[np.uint8, (3,)] = self.max_channel - self.min_channel
+        diff: NDArray[np.uint8] = self.max_channel - self.min_channel
         dominant_channel = np.argmax(diff)
-        return dominant_channel
+        return int(dominant_channel)
 
     @property
-    def average(self) -> np.ndarray:
+    def average(self) -> NDArray[np.uint8]:
         """
         Calculates the average color contained in the ColorBox.
 
@@ -80,7 +80,7 @@ class ColorBox:
         Returns:
             int: The volume of the ColorBox.
         """
-        diff: NDArray[np.uint8, (3,)] = self.max_channel - self.min_channel
+        diff: NDArray[np.uint8] = self.max_channel - self.min_channel
         return np.prod(diff).item()
 
     def split(self) -> list["ColorBox"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pylette"
-version = "4.0.0"
+version = "4.0.1"
 description = "A Python library for extracting color palettes from images."
 authors = ["Ivar Stangeby"]
 license = "MIT"


### PR DESCRIPTION
## Motivation:

I would like all color extraction methods to have a unified interface. This makes it easier to subsequently implement additional extractors. 

This PR introduces the `ColorExtractor` protocol, and a `ColorExtractorBase` that serves as a base-class for classes that want to implement the protocol. 

It also rewrites the `MedianCut` and `KMeans` extraction methods in terms of this new protocol / base class. 

Also: 
- **Fix misc typing in utils**
