### PR TITLE
fixes: Add smoke test / open-cv dependency / types-module

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Run automated tests
 
 on:

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -35,3 +35,27 @@ jobs:
         run: uv run pyright
       - name: Run the automated tests (for example)
         run: uv run pytest -v
+
+  smoke-test:
+    runs-on: ubuntu-latest
+    needs: ci
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - name: Create fresh virtual environment for smoke test
+        run: uv venv .smoke-test-venv
+      - name: Install package in fresh environment
+        run: |
+          source .smoke-test-venv/bin/activate
+          uv sync --frozen --extra dev
+      - name: Run smoke test
+        run: |
+          source .smoke-test-venv/bin/activate
+          python smoke_test.py

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Install package in fresh environment
         run: |
           source .smoke-test-venv/bin/activate
-          uv sync --frozen --extra dev
+          uv sync --frozen --active
       - name: Run smoke test
         run: |
           source .smoke-test-venv/bin/activate

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -40,7 +40,6 @@ jobs:
 
   smoke-test:
     runs-on: ubuntu-latest
-    needs: ci
     steps:
       - uses: actions/checkout@v4
       - name: Install Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Released
 
+## 5.1.0 - 22/08/2025
+
+### Fixed
+- Added OpenCV as required dependency
+
+### Added
+- Expose the `types`-module to the user, so they can import Pylette types from `Pylette.types`.
+
 ## 5.0.1 - 22/08/2025
 
 ### Changed

--- a/Pylette/__init__.py
+++ b/Pylette/__init__.py
@@ -1,6 +1,6 @@
+import Pylette.src.types as types
 from Pylette.src.color import Color
 from Pylette.src.color_extraction import batch_extract_colors, extract_colors
 from Pylette.src.palette import Palette
-from Pylette.src.types import ImageInput
 
-__all__ = ["extract_colors", "batch_extract_colors", "Palette", "Color", "ImageInput"]
+__all__ = ["extract_colors", "batch_extract_colors", "Palette", "Color", "types"]

--- a/Pylette/__init__.py
+++ b/Pylette/__init__.py
@@ -1,4 +1,4 @@
-import Pylette.src.types as types
+from Pylette import types
 from Pylette.src.color import Color
 from Pylette.src.color_extraction import batch_extract_colors, extract_colors
 from Pylette.src.palette import Palette

--- a/Pylette/src/extractors/k_means.py
+++ b/Pylette/src/extractors/k_means.py
@@ -1,11 +1,13 @@
 import numpy as np
 from numpy.typing import NDArray
+from typing_extensions import override
 
 from Pylette.src.color import Color
 from Pylette.src.extractors.protocol import NP_T, ColorExtractorBase
 
 
 class KMeansExtractor(ColorExtractorBase):
+    @override
     def extract(self, arr: NDArray[NP_T], height: int, width: int, palette_size: int) -> list[Color]:
         """
         Extracts a color palette using KMeans.

--- a/Pylette/src/extractors/median_cut.py
+++ b/Pylette/src/extractors/median_cut.py
@@ -1,5 +1,6 @@
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
+from typing_extensions import override
 
 from Pylette.src.color import Color
 from Pylette.src.extractors.protocol import NP_T, ColorExtractorBase
@@ -121,6 +122,7 @@ class ColorBox:
 
 
 class MedianCutExtractor(ColorExtractorBase):
+    @override
     def extract(self, arr: NDArray[NP_T], height: int, width: int, palette_size: int) -> list[Color]:
         """
         Extracts a color palette using the median cut algorithm.

--- a/Pylette/types.py
+++ b/Pylette/types.py
@@ -1,0 +1,58 @@
+"""
+This module allows users to import types in multiple ways:
+- from pylette.types import ImageInput
+- import pylette.types as types
+"""
+
+from Pylette.src.types import (
+    ArrayImage,
+    ArrayLike,
+    BatchResult,
+    BytesImage,
+    ColorArray,
+    ColorSpace,
+    ColorTuple,
+    CV2Image,
+    ExtractionMethod,
+    ExtractionParams,
+    FloatArray,
+    ImageInfo,
+    ImageInput,
+    ImageLike,
+    IntArray,
+    PaletteMetaData,
+    PathLikeImage,
+    PILImage,
+    ProcessingStats,
+    RGBATuple,
+    RGBTuple,
+    SourceType,
+    URLImage,
+)
+
+# Define what gets exported with "from pylette.types import *"
+__all__ = [
+    "ImageInput",
+    "ImageLike",
+    "ArrayLike",
+    "PathLikeImage",
+    "URLImage",
+    "BytesImage",
+    "ArrayImage",
+    "CV2Image",
+    "PILImage",
+    "ColorArray",
+    "FloatArray",
+    "IntArray",
+    "RGBTuple",
+    "RGBATuple",
+    "ColorTuple",
+    "ExtractionMethod",
+    "ColorSpace",
+    "SourceType",
+    "ExtractionParams",
+    "ImageInfo",
+    "ProcessingStats",
+    "PaletteMetaData",
+    "BatchResult",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,11 @@ dev = [
 [project.scripts]
 pylette = "Pylette.cmd:main_typer"
 
+[tool.pytest.ini_options]
+testpaths = [
+  "tests"
+]
+
 [tool.pyright]
 include = ["Pylette"]
 exclude = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylette"
-version = "5.0.1"
+version = "5.1.0"
 description = "A Python library for extracting color palettes from images."
 authors = [
     {name = "Ivar Stangeby"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Typing :: Typed"
 ]
 dependencies = [
     "numpy>=1.26.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.26.4",
+    "opencv-python>=4.11.0.86",
     "pillow>=9.3,<11.0",
     "requests>=2.32.3",
     "scikit-learn>=1.2",

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -1,0 +1,124 @@
+"""
+Smoke test for Pylette library.
+Tests basic functionality to ensure the library works correctly after installation.
+
+This is here because I've pushed changes twice now that broke the library... :(
+"""
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from PIL import Image
+
+import Pylette
+
+
+def test_library_import():
+    """Test that the library can be imported successfully."""
+    print("✓ Testing library import...")
+    # Import should work if we get here
+    assert hasattr(Pylette, "extract_colors"), "extract_colors function should be available"
+    print("  Import successful")
+
+
+def test_basic_color_extraction():
+    """Test basic color extraction functionality."""
+    print("✓ Testing basic color extraction...")
+
+    # Create a simple test image
+    test_img = Image.new("RGB", (100, 100), color="red")
+    palette = Pylette.extract_colors(test_img, palette_size=5)
+
+    assert len(palette) <= 5, f"Palette size should not exceed 5, got {len(palette)}"
+    assert len(palette) > 0, "Should extract at least one color"
+
+    print(f"  Extracted {len(palette)} colors successfully")
+
+
+def test_cli_functionality():
+    """Test CLI functionality."""
+    print("✓ Testing CLI functionality...")
+
+    # Create a temporary test image
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+        test_img = Image.new("RGB", (50, 50), color="blue")
+        test_img.save(tmp.name)
+
+        # Test CLI command
+        result = subprocess.run(
+            [sys.executable, "-m", "Pylette.cmd", tmp.name, "--palette_size", "3"], capture_output=True, text=True
+        )
+
+        if result.returncode != 0:
+            raise RuntimeError(f"CLI test failed: {result.stderr}")
+
+        # Clean up
+        Path(tmp.name).unlink()
+
+    print("  CLI test passed")
+
+
+def test_extraction_methods():
+    """Test different extraction methods."""
+    print("✓ Testing different extraction methods...")
+
+    test_img = Image.new("RGB", (50, 50), color="green")
+
+    # Test K-means extractor
+    kmeans_palette = Pylette.extract_colors(test_img, palette_size=3, mode=Pylette.types.ExtractionMethod.KM)
+    assert len(kmeans_palette) <= 3, "K-means should respect palette size"
+    print(f"  K-means extracted {len(kmeans_palette)} colors")
+
+    # Test Median cut extractor
+    mediancut_palette = Pylette.extract_colors(test_img, palette_size=3, mode=Pylette.types.ExtractionMethod.MC)
+    assert len(mediancut_palette) <= 3, "Median cut should respect palette size"
+    print(f"  Median cut extracted {len(mediancut_palette)} colors")
+
+
+def test_json_export():
+    """Test JSON export functionality."""
+    print("✓ Testing JSON export...")
+
+    test_img = Image.new("RGB", (50, 50), color="purple")
+    palette = Pylette.extract_colors(test_img, palette_size=2)
+
+    # Test JSON export
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmp:
+        palette.to_json(tmp.name)
+
+        # Verify JSON file was created and is valid
+        with open(tmp.name, "r") as f:
+            data = json.load(f)
+            assert "colors" in data, "JSON should contain 'colors' key"
+            assert len(data["colors"]) <= 2, f"Should have at most 2 colors, got {len(data['colors'])}"
+
+        # Clean up
+        Path(tmp.name).unlink()
+
+    print("  JSON export test passed")
+
+
+def main():
+    """Run all smoke tests."""
+    print("🧪 Starting Pylette smoke test...")
+
+    try:
+        test_library_import()
+        test_basic_color_extraction()
+        test_cli_functionality()
+        test_extraction_methods()
+        test_json_export()
+
+        print("✅ All smoke tests passed!")
+        print("🎉 Pylette is working correctly")
+
+    except Exception as e:
+        print(f"❌ Smoke test failed: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -764,7 +764,7 @@ wheels = [
 
 [[package]]
 name = "pylette"
-version = "5.0.1"
+version = "5.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },

--- a/uv.lock
+++ b/uv.lock
@@ -769,6 +769,7 @@ source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "opencv-python" },
     { name = "pillow" },
     { name = "requests" },
     { name = "scikit-learn" },
@@ -801,6 +802,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.5.27" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'dev'", specifier = ">=0.25.1" },
     { name = "numpy", specifier = ">=1.26.4" },
+    { name = "opencv-python", specifier = ">=4.11.0.86" },
     { name = "opencv-python", marker = "extra == 'dev'", specifier = ">=4.10.0.84" },
     { name = "pillow", specifier = ">=9.3,<11.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7.1" },


### PR DESCRIPTION
I inadvertently merged a change in dependencies that broke runtime. This PR does multiple things:

1. Adds a smoke-test so this does not happen again. (Runs pylette from the user's perspective, in a fresh environment with no development dependencies). 
2. Add the Pylette.types module, so the user can import internal Pylette types for type hinting. 
3. Add OpenCV as dependency (might remove this later once I get type hints to work properly)
4. Move the py.typed file to root of Pylette. 