### PR TITLE
fix(deps): declare typing-extensions as runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Released
 
+## 5.2.0 - 27/06/2026
+
+### Fixed
+
+- Declare `typing-extensions` as runtime dependency
+
 ## 5.1.2 - 03/02/2026
 
 ## Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylette"
-version = "5.1.2"
+version = "5.2.0"
 description = "A Python library for extracting color palettes from images."
 authors = [
     {name = "Ivar Stangeby"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "requests>=2.32.3",
     "scikit-learn>=1.2",
     "typer>=0.12.5",
+    "typing-extensions>=4.4.0",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -803,7 +803,7 @@ wheels = [
 
 [[package]]
 name = "pylette"
-version = "5.1.2"
+version = "5.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },

--- a/uv.lock
+++ b/uv.lock
@@ -813,6 +813,7 @@ dependencies = [
     { name = "requests" },
     { name = "scikit-learn" },
     { name = "typer" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -852,6 +853,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5.0" },
     { name = "scikit-learn", specifier = ">=1.2" },
     { name = "typer", specifier = ">=0.12.5" },
+    { name = "typing-extensions", specifier = ">=4.4.0" },
 ]
 provides-extras = ["dev"]
 
@@ -1275,11 +1277,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.14.1"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673, upload-time = "2025-07-04T13:28:34.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76", size = 43906, upload-time = "2025-07-04T13:28:32.743Z" },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`Pylette/src/extractors/k_means.py:3` and `median_cut.py:3` both import `from typing_extensions import override`, **unconditionally**, but `typing-extensions` was never listed in `[project.dependencies]`. Present only through the dev tooling, so import doesn't fail on CI.

On a clean install:

```
File ".../Pylette/src/extractors/k_means.py", line 3, in <module>
    from typing_extensions import override
ModuleNotFoundError: No module named 'typing_extensions'
```

## Reproduce (3.12)

```bash
$ uv venv --python 3.12 /tmp/pylette-repro
Using CPython 3.12.13
Creating virtual environment at: /tmp/pylette-repro
Activate with: source /tmp/pylette-repro/bin/activate
$ uv pip list
Using Python 3.12.13 environment at: /tmp/pylette-repro
$ uv pip install pylette==5.1.2
Using Python 3.12.13 environment at: /tmp/pylette-repro
Resolved 20 packages in 293ms
░░░░░░░░░░░░░░░░░░░░ [0/20] Installing wheels...                                                                                                                                               warning: Failed to hardlink files; falling back to full copy. This may lead to degraded performance.
         If the cache and target directories are on different filesystems, hardlinking may not be supported.
         If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning.
Installed 20 packages in 81ms
 + annotated-doc==0.0.4
 + certifi==2026.5.20
 + charset-normalizer==3.4.7
 + idna==3.17
 + joblib==1.5.3
 + markdown-it-py==4.2.0
 + mdurl==0.1.2
 + numpy==2.4.6
 + opencv-python==4.13.0.92
 + pillow==12.2.0
 + pygments==2.20.0
 + pylette==5.1.2
 + requests==2.34.2
 + rich==15.0.0
 + scikit-learn==1.8.0
 + scipy==1.17.1
 + shellingham==1.5.4
 + threadpoolctl==3.6.0
 + typer==0.26.3
 + urllib3==2.7.0
$ uv run python -c "import Pylette"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/tmp/pylette-repro/lib/python3.12/site-packages/Pylette/__init__.py", line 3, in <module>
    from Pylette.src.color_extraction import batch_extract_colors, extract_colors
  File "/tmp/pylette-repro/lib/python3.12/site-packages/Pylette/src/color_extraction.py", line 12, in <module>
    from Pylette.src.extractors.k_means import k_means_extraction
  File "/tmp/pylette-repro/lib/python3.12/site-packages/Pylette/src/extractors/k_means.py", line 3, in <module>
    from typing_extensions import override
ModuleNotFoundError: No module named 'typing_extensions'
$ uv pip list
Using Python 3.12.13 environment at: /tmp/pylette-repro
Package            Version
------------------ ---------
annotated-doc      0.0.4
certifi            2026.5.20
charset-normalizer 3.4.7
idna               3.17
joblib             1.5.3
markdown-it-py     4.2.0
mdurl              0.1.2
numpy              2.4.6
opencv-python      4.13.0.92
pillow             12.2.0
pygments           2.20.0
pylette            5.1.2
requests           2.34.2
rich               15.0.0
scikit-learn       1.8.0
scipy              1.17.1
shellingham        1.5.4
threadpoolctl      3.6.0
typer              0.26.3
urllib3            2.7.0
```
Both the installation and final `uv pip list` confirm that package is absent.

## Fix

Declaring it unconditionally fixes the issue. Confirmed with `typing-extensions==4.14.1` and `typing-extensions==4.15.0`.

### Alternative: guard the import

Versions 3.12+ have `typing.override` in stdlib, while carrying no runtime dep. To take advantage:

- Guard the import in both situations:
```python
import sys
if sys.version_info >= (3, 12):
    from typing import override
else:
    from typing_extensions import override
```
- Mark the dependency, so it installs only when needed:
`typing-extensions>=4.4.0; python_version < '3.12'`