### PR TITLE
fix(citation): Catch citation version drift in CI

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -38,6 +38,28 @@ jobs:
       - name: Run the automated tests (for example)
         run: uv run pytest -v
 
+  citation-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Check CITATION.cff version matches pyproject.toml
+        run: |
+          python - <<'PY'
+          import pathlib, re, sys, tomllib
+          proj = tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"]
+          cff = pathlib.Path("CITATION.cff").read_text()
+          m = re.search(r'^version:\s*["\']?([^"\'\s]+)', cff, re.MULTILINE)
+          if m is None:
+              sys.exit("Could not find 'version:' in CITATION.cff")
+          if proj != m.group(1):
+              sys.exit(f"Version mismatch: pyproject.toml={proj} but CITATION.cff={m.group(1)}")
+          print(f"OK: versions match ({proj})")
+          PY
+
   smoke-test:
     runs-on: ubuntu-latest
     steps:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,8 +5,8 @@ authors:
   given-names: "Ivar"
   orcid: "https://orcid.org/0000-0002-7697-7526"
 title: "Pylette"
-version: 4.0.1
+version: 5.3.0
 doi: 10.5281/zenodo.14757253
-date-released: 2025-01-27
+date-released: 2026-06-27
 date-published: 2024-02-09
-url: "https://github.com/qtiptip/pylette"
+url: "https://github.com/qTipTip/Pylette"


### PR DESCRIPTION
I've been forgetting to bump versions in the citation file. 