### PR TITLE
fix: Reshape bug with MedianCut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `extract_colors` now resolves the extraction algorithm through the registry
   instead of dispatching on the extraction method directly.
+- **Extractor `extract()` signature**: Dropped the unused `height` and `width`
+  parameters from `ColorExtractor.extract()`, `ColorExtractorBase.extract()`, and
+  all built-in extractors. The signature is now `extract(arr, palette_size)`.
+  Spatial dimensions are no longer needed since extractors reshape by the array's
+  actual length. Custom extractors implementing the protocol must update their
+  signature accordingly.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Use `get_extractor(...)` (or the registered `KMeansExtractor` /
   `MedianCutExtractor` classes) instead.
 
+### Fixed
+
+- **Reshape bug with alpha masking**: Extractors reshaped the pixel array to
+  `(height * width, n_channels)`, but after alpha masking the valid-pixel count
+  can be smaller than `height * width`. This caused the reshape to either raise
+  or silently produce a wrongly-shaped array. Extractors now reshape by the
+  array's actual length (`(-1, n_channels)`), so masked extraction works across
+  all extraction methods.
+
 
 # Released
 

--- a/Pylette/src/color_extraction.py
+++ b/Pylette/src/color_extraction.py
@@ -204,7 +204,7 @@ def extract_colors(
 
     # Color extraction
     extractor = get_extractor(mode)
-    colors = extractor.extract(arr=valid_pixels, height=height, width=width, palette_size=palette_size)
+    colors = extractor.extract(arr=valid_pixels, palette_size=palette_size)
 
     if colors:
         if sort_mode == "luminance":

--- a/Pylette/src/extractors/k_means.py
+++ b/Pylette/src/extractors/k_means.py
@@ -11,7 +11,7 @@ from Pylette.types import ExtractionMethod
 @register(ExtractionMethod.KM)
 class KMeansExtractor(ColorExtractorBase):
     @override
-    def extract(self, arr: NDArray[NP_T], height: int, width: int, palette_size: int) -> list[Color]:
+    def extract(self, arr: NDArray[NP_T], palette_size: int) -> list[Color]:
         """
         Extracts a color palette using KMeans.
 

--- a/Pylette/src/extractors/median_cut.py
+++ b/Pylette/src/extractors/median_cut.py
@@ -125,21 +125,19 @@ class ColorBox:
 @register(ExtractionMethod.MC)
 class MedianCutExtractor(ColorExtractorBase):
     @override
-    def extract(self, arr: NDArray[NP_T], height: int, width: int, palette_size: int) -> list[Color]:
+    def extract(self, arr: NDArray[NP_T], palette_size: int) -> list[Color]:
         """
         Extracts a color palette using the median cut algorithm.
 
         Parameters:
             arr (np.ndarray): The input array.
-            height (int): The height of the image.
-            width (int): The width of the image.
             palette_size (int): The number of colors to extract from the image.
 
         Returns:
             list[Color]: A list of colors extracted from the image.
         """
 
-        arr = self._reshape_array(arr=arr, height=height, width=width)
+        arr = self._reshape_array(arr=arr)
         valid_pixel_count = arr.shape[0]
         boxes = [ColorBox(arr)]
         while len(boxes) < palette_size:

--- a/Pylette/src/extractors/oklab.py
+++ b/Pylette/src/extractors/oklab.py
@@ -89,13 +89,11 @@ class OKLabKMeansExtractor(ColorExtractorBase):
     """K-means clustering performed in OKLab (perceptual) space."""
 
     @override
-    def extract(self, arr: NDArray[NP_T], height: int, width: int, palette_size: int) -> list[Color]:
+    def extract(self, arr: NDArray[NP_T], palette_size: int) -> list[Color]:
         """Extract a palette by clustering pixels in OKLab space.
 
         Parameters:
             arr: Pixel array of shape ``(..., C)`` with ``C >= 3``; RGB(A), uint8.
-            height: Image height (unused; retained for protocol compatibility).
-            width: Image width (unused; retained for protocol compatibility).
             palette_size: Number of clusters / colors to extract.
 
         Returns:

--- a/Pylette/src/extractors/protocol.py
+++ b/Pylette/src/extractors/protocol.py
@@ -20,4 +20,6 @@ class ColorExtractorBase(ABC):
         pass
 
     def _reshape_array(self, arr: NDArray[NP_T], height: int, width: int) -> NDArray[NP_T]:
-        return arr.reshape((height * width, -1))
+        # Reshape to (n_pixels, n_channels) from the array's actual length.
+        # Spatial dimensions aren't needed for color clustering.
+        return arr.reshape((-1, arr.shape[-1]))

--- a/Pylette/src/extractors/protocol.py
+++ b/Pylette/src/extractors/protocol.py
@@ -11,15 +11,15 @@ NP_T = TypeVar("NP_T", bound=np.generic, covariant=True)
 
 @runtime_checkable
 class ColorExtractor(Protocol):
-    def extract(self, arr: NDArray[NP_T], height: int, width: int, palette_size: int) -> list[Color]: ...
+    def extract(self, arr: NDArray[NP_T], palette_size: int) -> list[Color]: ...
 
 
 class ColorExtractorBase(ABC):
     @abstractmethod
-    def extract(self, arr: NDArray[NP_T], height: int, width: int, palette_size: int) -> list[Color]:
+    def extract(self, arr: NDArray[NP_T], palette_size: int) -> list[Color]:
         pass
 
-    def _reshape_array(self, arr: NDArray[NP_T], height: int, width: int) -> NDArray[NP_T]:
+    def _reshape_array(self, arr: NDArray[NP_T]) -> NDArray[NP_T]:
         # Reshape to (n_pixels, n_channels) from the array's actual length.
         # Spatial dimensions aren't needed for color clustering.
         return arr.reshape((-1, arr.shape[-1]))

--- a/tests/integration/test_alpha_masking.py
+++ b/tests/integration/test_alpha_masking.py
@@ -1,0 +1,40 @@
+"""
+A regression test: median cut must not mis-shape pixels when alpha masking
+removes some of them.
+
+Before the fix, MedianCutExtractor reshaped to (height * width, n_channels).
+After alpha masking the valid-pixel count can be < height * width, so that
+reshape either raised or it silently produced an array with the wrong shape.
+The extractor now reshapes by the array's actual length.
+"""
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from Pylette import extract_colors
+from Pylette.types import ExtractionMethod
+
+
+@pytest.fixture
+def half_transparent_image() -> Image.Image:
+    """64x64 RGBA image whose odd rows are fully transparent (alpha = 0)."""
+    arr = np.zeros((64, 64, 4), dtype=np.uint8)
+    arr[..., :3] = np.random.default_rng(0).integers(0, 256, (64, 64, 3))
+    arr[::2, :, 3] = 255
+    arr[1::2, :, 3] = 0
+    return Image.fromarray(arr, "RGBA")
+
+
+@pytest.mark.parametrize("mode", list(ExtractionMethod))
+def test_extraction_survives_alpha_masking(half_transparent_image: Image.Image, mode: ExtractionMethod):
+    # threshold=0 masks the fully-transparent rows, so valid pixels < height*width.
+    palette = extract_colors(
+        half_transparent_image,
+        palette_size=5,
+        mode=mode,
+        resize=False,
+        alpha_mask_threshold=0,
+    )
+    assert len(palette) <= 5
+    assert sum(palette.frequencies) == pytest.approx(1.0)


### PR DESCRIPTION
The reshape method was using width and height from the original image. After alpha masking, some pixels might be removed, causing this to raise downstream. Turns out we do not need width/height at all, so removing from the protocol. 
- **fix reshape bug**
- **add a regression test that covers all extraction methods**
