### PR TITLE
chore(rename): Change import symbol `Pylette` to lowercase `pylette`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Extractor registry**: A registry for color-extraction algorithms, exposing
-  `register`, `get_extractor`, and `available_methods` from `Pylette.src.extractors`.
+  `register`, `get_extractor`, and `available_methods` from `pylette.src.extractors`.
   Extractors are now registered via the `@register(...)` decorator, making it
   possible to plug in custom extraction methods.
 - **OKLab extractor**: New `ExtractionMethod.OKLAB` extraction mode that runs
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Import package renamed `Pylette` → `pylette`**
+  Update imports: `from Pylette import x` → `from pylette import x`.
 - `extract_colors` now resolves the extraction algorithm through the registry
   instead of dispatching on the extraction method directly.
 - **Extractor `extract()` signature**: Dropped the unused `height` and `width`

--- a/Pylette/__init__.py
+++ b/Pylette/__init__.py
@@ -1,6 +1,0 @@
-from Pylette import types
-from Pylette.src.color import Color
-from Pylette.src.color_extraction import batch_extract_colors, extract_colors
-from Pylette.src.palette import Palette
-
-__all__ = ["extract_colors", "batch_extract_colors", "Palette", "Color", "types"]

--- a/Pylette/src/extractors/__init__.py
+++ b/Pylette/src/extractors/__init__.py
@@ -1,7 +1,0 @@
-# Import for registration side-effect
-from Pylette.src.extractors import k_means as _k_means  # type: ignore # noqa: F401
-from Pylette.src.extractors import median_cut as _median_cut  # type: ignore  # noqa: F401
-from Pylette.src.extractors import oklab as _oklab  # type: ignore  # noqa: F401
-from Pylette.src.extractors.registry import available_methods, get_extractor, register
-
-__all__ = ["available_methods", "get_extractor", "register"]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 
-[![PyPI version](https://badge.fury.io/py/Pylette.svg)](https://badge.fury.io/py/Pylette)
+[![PyPI version](https://badge.fury.io/py/pylette.svg)](https://badge.fury.io/py/pylette)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/pylette)
 [![Built with Material for MkDocs](https://img.shields.io/badge/Material_for_MkDocs-526CFE?logo=MaterialForMkDocs&logoColor=white)](https://squidfunk.github.io/mkdocs-material/)
 ![Dependabot](https://img.shields.io/badge/dependabot-enabled-025E8C?logo=dependabot&logoColor=white)
@@ -40,13 +40,13 @@ Pylette helps you extract color palettes from images. Use the command-line inter
 You can easily install Pylette using pip:
 
 ```shell
-pip install Pylette
+pip install pylette
 ```
 
 Or if you prefer using uv:
 
 ```shell
-uv add Pylette
+uv add pylette
 ```
 
 ## Command Line Usage
@@ -118,7 +118,7 @@ pylette image.jpg --no-stdout --display-colors
 For programmatic usage and advanced workflows:
 
 ```python
-from Pylette import extract_colors
+from pylette import extract_colors
 
 # Extract palette with rich metadata
 palette = extract_colors(image='image.jpg', palette_size=8)
@@ -146,7 +146,7 @@ palette.export('my_colors', colorspace='hls', include_metadata=True)
 For processing multiple images programmatically:
 
 ```python
-from Pylette import batch_extract_colors
+from pylette import batch_extract_colors
 
 # Process multiple images with parallel processing
 results = batch_extract_colors(
@@ -227,7 +227,7 @@ pylette transparent.png --alpha-mask-threshold 128
 
 ```python
 # Python: Same functionality
-from Pylette import extract_colors
+from pylette import extract_colors
 palette = extract_colors('transparent.png', alpha_mask_threshold=128)
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 
 
 
-[![PyPI version](https://badge.fury.io/py/Pylette.svg)](https://badge.fury.io/py/Pylette)
+[![PyPI version](https://badge.fury.io/py/pylette.svg)](https://badge.fury.io/py/pylette)
 [![Downloads](http://pepy.tech/badge/pylette)](http://pepy.tech/project/pylette)
 [![Built with Material for MkDocs](https://img.shields.io/badge/Material_for_MkDocs-526CFE?logo=MaterialForMkDocs&logoColor=white)](https://squidfunk.github.io/mkdocs-material/)
 ![Dependabot](https://img.shields.io/badge/dependabot-enabled-025E8C?logo=dependabot&logoColor=white)
@@ -40,13 +40,13 @@ Pylette helps you extract color palettes from images. Use the command-line inter
 You can easily install Pylette using pip:
 
 ```shell
-pip install Pylette
+pip install pylette
 ```
 
 Or if you prefer using uv:
 
 ```shell
-uv add Pylette
+uv add pylette
 ```
 
 ## Command Line Usage
@@ -90,7 +90,7 @@ For programmatic usage and advanced workflows:
 !!! example "Python API"
 
     ```python
-    from Pylette import extract_colors
+    from pylette import extract_colors
 
     # Extract palette with rich metadata
     palette = extract_colors(image='image.jpg', palette_size=8)
@@ -116,7 +116,7 @@ For programmatic usage and advanced workflows:
 !!! example "Batch Processing"
 
     ```python
-    from Pylette import batch_extract_colors
+    from pylette import batch_extract_colors
 
     # Process multiple images with parallel processing
     results = batch_extract_colors(
@@ -142,7 +142,7 @@ The Python library provides full programmatic access to all CLI features plus de
     For images with transparency (PNG files with alpha channels), you can use the `alpha_mask_threshold` parameter to exclude transparent or semi-transparent pixels:
 
     ```python
-    from Pylette import extract_colors
+    from pylette import extract_colors
 
     # Extract colors from a transparent PNG, ignoring pixels with alpha < 128
     palette = extract_colors(

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -13,37 +13,37 @@ and the `Palette` and `Color` classes, which are used to work with the extracted
 - **Batch Processing**: Process multiple images with parallel execution support
 
 
-::: Pylette.extract_colors
+::: pylette.extract_colors
 
-::: Pylette.batch_extract_colors
+::: pylette.batch_extract_colors
 
-::: Pylette.Palette
+::: pylette.Palette
 
-::: Pylette.Color
+::: pylette.Color
 
 
 ## Core Types:
 
-::: Pylette.types.ArrayImage
-::: Pylette.types.ArrayLike
-::: Pylette.types.BatchResult
-::: Pylette.types.BytesImage
-::: Pylette.types.ColorArray
-::: Pylette.types.ColorSpace
-::: Pylette.types.ColorTuple
-::: Pylette.types.CV2Image
-::: Pylette.types.ExtractionMethod
-::: Pylette.types.ExtractionParams
-::: Pylette.types.FloatArray
-::: Pylette.types.ImageInfo
-::: Pylette.types.ImageInput
-::: Pylette.types.ImageLike
-::: Pylette.types.IntArray
-::: Pylette.types.PaletteMetaData
-::: Pylette.types.PathLikeImage
-::: Pylette.types.PILImage
-::: Pylette.types.ProcessingStats
-::: Pylette.types.RGBATuple
-::: Pylette.types.RGBTuple
-::: Pylette.types.SourceType
-::: Pylette.types.URLImage
+::: pylette.types.ArrayImage
+::: pylette.types.ArrayLike
+::: pylette.types.BatchResult
+::: pylette.types.BytesImage
+::: pylette.types.ColorArray
+::: pylette.types.ColorSpace
+::: pylette.types.ColorTuple
+::: pylette.types.CV2Image
+::: pylette.types.ExtractionMethod
+::: pylette.types.ExtractionParams
+::: pylette.types.FloatArray
+::: pylette.types.ImageInfo
+::: pylette.types.ImageInput
+::: pylette.types.ImageLike
+::: pylette.types.IntArray
+::: pylette.types.PaletteMetaData
+::: pylette.types.PathLikeImage
+::: pylette.types.PILImage
+::: pylette.types.ProcessingStats
+::: pylette.types.RGBATuple
+::: pylette.types.RGBTuple
+::: pylette.types.SourceType
+::: pylette.types.URLImage

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,7 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          paths: ["Pylette"]
+          paths: ["pylette"]
           load_external_modules: true
           options:
             show_signature: false

--- a/pylette/__init__.py
+++ b/pylette/__init__.py
@@ -1,0 +1,6 @@
+from pylette import types
+from pylette.src.color import Color
+from pylette.src.color_extraction import batch_extract_colors, extract_colors
+from pylette.src.palette import Palette
+
+__all__ = ["extract_colors", "batch_extract_colors", "Palette", "Color", "types"]

--- a/pylette/cmd.py
+++ b/pylette/cmd.py
@@ -7,9 +7,9 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from Pylette.src.cli_utils import PyletteProgress
-from Pylette.src.color_extraction import batch_extract_colors
-from Pylette.src.types import BatchResult, ColorSpace, ExtractionMethod
+from pylette.src.cli_utils import PyletteProgress
+from pylette.src.color_extraction import batch_extract_colors
+from pylette.src.types import BatchResult, ColorSpace, ExtractionMethod
 
 
 class SortBy(str, Enum):

--- a/pylette/src/cli_utils.py
+++ b/pylette/src/cli_utils.py
@@ -6,7 +6,7 @@ from rich.progress import BarColumn, Progress, TaskID, TextColumn, TimeElapsedCo
 from rich.table import Table
 from rich.text import Text
 
-from Pylette.src.color import Color
+from pylette.src.color import Color
 
 
 class RecentlyCompletedDisplay:

--- a/pylette/src/color.py
+++ b/pylette/src/color.py
@@ -3,7 +3,7 @@ from typing import cast
 
 import numpy as np
 
-from Pylette.src.types import ColorSpace
+from pylette.src.types import ColorSpace
 
 # Weights for calculating luminance
 luminance_weights = np.array([0.2126, 0.7152, 0.0722])

--- a/pylette/src/color_extraction.py
+++ b/pylette/src/color_extraction.py
@@ -9,9 +9,9 @@ from typing import Callable, Literal, Sequence
 import numpy as np
 from PIL import Image
 
-from Pylette.src.extractors.registry import get_extractor
-from Pylette.src.palette import Palette
-from Pylette.src.types import (
+from pylette.src.extractors.registry import get_extractor
+from pylette.src.palette import Palette
+from pylette.src.types import (
     BatchResult,
     ExtractionMethod,
     ExtractionParams,

--- a/pylette/src/extractors/__init__.py
+++ b/pylette/src/extractors/__init__.py
@@ -1,0 +1,7 @@
+# Import for registration side-effect
+from pylette.src.extractors import k_means as _k_means  # type: ignore # noqa: F401
+from pylette.src.extractors import median_cut as _median_cut  # type: ignore  # noqa: F401
+from pylette.src.extractors import oklab as _oklab  # type: ignore  # noqa: F401
+from pylette.src.extractors.registry import available_methods, get_extractor, register
+
+__all__ = ["available_methods", "get_extractor", "register"]

--- a/pylette/src/extractors/k_means.py
+++ b/pylette/src/extractors/k_means.py
@@ -2,10 +2,10 @@ import numpy as np
 from numpy.typing import NDArray
 from typing_extensions import override
 
-from Pylette.src.color import Color
-from Pylette.src.extractors.protocol import NP_T, ColorExtractorBase
-from Pylette.src.extractors.registry import register
-from Pylette.types import ExtractionMethod
+from pylette.src.color import Color
+from pylette.src.extractors.protocol import NP_T, ColorExtractorBase
+from pylette.src.extractors.registry import register
+from pylette.types import ExtractionMethod
 
 
 @register(ExtractionMethod.KM)

--- a/pylette/src/extractors/median_cut.py
+++ b/pylette/src/extractors/median_cut.py
@@ -2,10 +2,10 @@ import numpy as np
 from numpy.typing import ArrayLike, NDArray
 from typing_extensions import override
 
-from Pylette.src.color import Color
-from Pylette.src.extractors.protocol import NP_T, ColorExtractorBase
-from Pylette.src.extractors.registry import register
-from Pylette.src.types import ColorArray, ExtractionMethod
+from pylette.src.color import Color
+from pylette.src.extractors.protocol import NP_T, ColorExtractorBase
+from pylette.src.extractors.registry import register
+from pylette.src.types import ColorArray, ExtractionMethod
 
 
 class ColorBox:

--- a/pylette/src/extractors/oklab.py
+++ b/pylette/src/extractors/oklab.py
@@ -26,10 +26,10 @@ import numpy as np
 from numpy.typing import NDArray
 from typing_extensions import override
 
-from Pylette.src.color import Color
-from Pylette.src.extractors.protocol import NP_T, ColorExtractorBase
-from Pylette.src.extractors.registry import register
-from Pylette.src.types import ExtractionMethod, FloatArray
+from pylette.src.color import Color
+from pylette.src.extractors.protocol import NP_T, ColorExtractorBase
+from pylette.src.extractors.registry import register
+from pylette.src.types import ExtractionMethod, FloatArray
 
 
 # sRGB <-> linear sRGB (IEC 61966-2-1 transfer function)

--- a/pylette/src/extractors/protocol.py
+++ b/pylette/src/extractors/protocol.py
@@ -4,7 +4,7 @@ from typing import Protocol, TypeVar, runtime_checkable
 import numpy as np
 from numpy.typing import NDArray
 
-from Pylette.src.color import Color
+from pylette.src.color import Color
 
 NP_T = TypeVar("NP_T", bound=np.generic, covariant=True)
 

--- a/pylette/src/extractors/registry.py
+++ b/pylette/src/extractors/registry.py
@@ -4,8 +4,8 @@ Registry of color-extraction algorithms
 
 from typing import Callable, TypeVar
 
-from Pylette.src.extractors.protocol import ColorExtractor
-from Pylette.src.types import ExtractionMethod
+from pylette.src.extractors.protocol import ColorExtractor
+from pylette.src.types import ExtractionMethod
 
 _REGISTRY: dict[ExtractionMethod, ColorExtractor] = {}
 _E = TypeVar("_E", bound=ColorExtractor)

--- a/pylette/src/palette.py
+++ b/pylette/src/palette.py
@@ -3,8 +3,8 @@ import json
 import numpy as np
 from PIL import Image
 
-from Pylette.src.color import Color
-from Pylette.src.types import ColorSpace, ExtractionParams, ImageInfo, PaletteMetaData, ProcessingStats, SourceType
+from pylette.src.color import Color
+from pylette.src.types import ColorSpace, ExtractionParams, ImageInfo, PaletteMetaData, ProcessingStats, SourceType
 
 
 class Palette:

--- a/pylette/src/types.py
+++ b/pylette/src/types.py
@@ -1,5 +1,5 @@
 """
-Centralized type definitions for Pylette.
+Centralized type definitions for pylette.
 
 This module contains all the type aliases and protocols used throughout the Pylette library
 to ensure type safety and consistency.
@@ -16,7 +16,7 @@ from numpy.typing import NDArray
 from PIL import Image
 
 if TYPE_CHECKING:
-    from Pylette.src.palette import Palette
+    from pylette.src.palette import Palette
 
 
 class ImageLike(Protocol):

--- a/pylette/types.py
+++ b/pylette/types.py
@@ -4,7 +4,7 @@ This module allows users to import types in multiple ways:
 - import pylette.types as types
 """
 
-from Pylette.src.types import (
+from pylette.src.types import (
     ArrayImage,
     ArrayLike,
     BatchResult,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ select = [
 ]
 
 [tool.hatch.build.targets.wheel]
-packages = ["Pylette"]
+packages = ["pylette"]
 
 [project.optional-dependencies]
 dev = [
@@ -58,7 +58,7 @@ dev = [
 ]
 
 [project.scripts]
-pylette = "Pylette.cmd:main_typer"
+pylette = "pylette.cmd:main_typer"
 
 [tool.pytest.ini_options]
 testpaths = [
@@ -66,7 +66,7 @@ testpaths = [
 ]
 
 [tool.pyright]
-include = ["Pylette"]
+include = ["pylette"]
 exclude = ["tests"]
 typeCheckingMode = "strict"
 reportMissingImports = false

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -13,14 +13,14 @@ from pathlib import Path
 
 from PIL import Image
 
-import Pylette
+import pylette
 
 
 def test_library_import():
     """Test that the library can be imported successfully."""
     print("✓ Testing library import...")
     # Import should work if we get here
-    assert hasattr(Pylette, "extract_colors"), "extract_colors function should be available"
+    assert hasattr(pylette, "extract_colors"), "extract_colors function should be available"
     print("  Import successful")
 
 
@@ -30,7 +30,7 @@ def test_basic_color_extraction():
 
     # Create a simple test image
     test_img = Image.new("RGB", (100, 100), color="red")
-    palette = Pylette.extract_colors(test_img, palette_size=5)
+    palette = pylette.extract_colors(test_img, palette_size=5)
 
     assert len(palette) <= 5, f"Palette size should not exceed 5, got {len(palette)}"
     assert len(palette) > 0, "Should extract at least one color"
@@ -49,7 +49,7 @@ def test_cli_functionality():
 
         # Test CLI command
         result = subprocess.run(
-            [sys.executable, "-m", "Pylette.cmd", tmp.name, "--palette_size", "3"], capture_output=True, text=True
+            [sys.executable, "-m", "pylette.cmd", tmp.name, "--palette_size", "3"], capture_output=True, text=True
         )
 
         if result.returncode != 0:
@@ -68,12 +68,12 @@ def test_extraction_methods():
     test_img = Image.new("RGB", (50, 50), color="green")
 
     # Test K-means extractor
-    kmeans_palette = Pylette.extract_colors(test_img, palette_size=3, mode=Pylette.types.ExtractionMethod.KM)
+    kmeans_palette = pylette.extract_colors(test_img, palette_size=3, mode=pylette.types.ExtractionMethod.KM)
     assert len(kmeans_palette) <= 3, "K-means should respect palette size"
     print(f"  K-means extracted {len(kmeans_palette)} colors")
 
     # Test Median cut extractor
-    mediancut_palette = Pylette.extract_colors(test_img, palette_size=3, mode=Pylette.types.ExtractionMethod.MC)
+    mediancut_palette = pylette.extract_colors(test_img, palette_size=3, mode=pylette.types.ExtractionMethod.MC)
     assert len(mediancut_palette) <= 3, "Median cut should respect palette size"
     print(f"  Median cut extracted {len(mediancut_palette)} colors")
 
@@ -83,7 +83,7 @@ def test_json_export():
     print("✓ Testing JSON export...")
 
     test_img = Image.new("RGB", (50, 50), color="purple")
-    palette = Pylette.extract_colors(test_img, palette_size=2)
+    palette = pylette.extract_colors(test_img, palette_size=2)
 
     # Test JSON export
     with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmp:

--- a/tests/integration/test_alpha_masking.py
+++ b/tests/integration/test_alpha_masking.py
@@ -12,8 +12,8 @@ import numpy as np
 import pytest
 from PIL import Image
 
-from Pylette import extract_colors
-from Pylette.types import ExtractionMethod
+from pylette import extract_colors
+from pylette.types import ExtractionMethod
 
 
 @pytest.fixture

--- a/tests/integration/test_batch_processing.py
+++ b/tests/integration/test_batch_processing.py
@@ -1,5 +1,5 @@
-from Pylette import batch_extract_colors
-from Pylette.src.types import BytesImage, PathLikeImage, URLImage
+from pylette import batch_extract_colors
+from pylette.src.types import BytesImage, PathLikeImage, URLImage
 
 
 def test_batch_processing(

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
-from Pylette.cmd import pylette_app
+from pylette.cmd import pylette_app
 
 runner = CliRunner()
 

--- a/tests/integration/test_colorspaces.py
+++ b/tests/integration/test_colorspaces.py
@@ -6,9 +6,9 @@ import pytest
 from cv2.typing import MatLike
 from numpy.testing import assert_approx_equal
 
-from Pylette.src.color_extraction import extract_colors
-from Pylette.src.palette import Palette
-from Pylette.src.types import BytesImage, CV2Image, ExtractionMethod, PathLikeImage, PILImage, URLImage
+from pylette.src.color_extraction import extract_colors
+from pylette.src.palette import Palette
+from pylette.src.types import BytesImage, CV2Image, ExtractionMethod, PathLikeImage, PILImage, URLImage
 
 
 @pytest.fixture

--- a/tests/integration/test_extractor_registry.py
+++ b/tests/integration/test_extractor_registry.py
@@ -1,8 +1,8 @@
 import pytest
 
-from Pylette.src.extractors import available_methods, get_extractor
-from Pylette.src.extractors.protocol import ColorExtractor
-from Pylette.src.types import ExtractionMethod
+from pylette.src.extractors import available_methods, get_extractor
+from pylette.src.extractors.protocol import ColorExtractor
+from pylette.src.types import ExtractionMethod
 
 
 class TestRegistry:

--- a/tests/integration/test_json_export.py
+++ b/tests/integration/test_json_export.py
@@ -5,10 +5,10 @@ from pathlib import Path
 import pytest
 from typer.testing import CliRunner
 
-from Pylette import extract_colors
-from Pylette.cmd import pylette_app
-from Pylette.src.color import Color
-from Pylette.src.types import ColorSpace
+from pylette import extract_colors
+from pylette.cmd import pylette_app
+from pylette.src.color import Color
+from pylette.src.types import ColorSpace
 
 
 class TestJSONExport:

--- a/tests/integration/test_metadata.py
+++ b/tests/integration/test_metadata.py
@@ -1,8 +1,8 @@
 import pytest
 from PIL import Image
 
-from Pylette import extract_colors
-from Pylette.src.types import BytesImage, ExtractionMethod, PathLikeImage, URLImage
+from pylette import extract_colors
+from pylette.src.types import BytesImage, ExtractionMethod, PathLikeImage, URLImage
 
 
 @pytest.mark.parametrize("mode", [ExtractionMethod.KM, ExtractionMethod.MC])

--- a/tests/integration/test_oklab.py
+++ b/tests/integration/test_oklab.py
@@ -7,14 +7,14 @@ import numpy as np
 import pytest
 from PIL import Image
 
-from Pylette import extract_colors
-from Pylette.src.extractors.oklab import (
+from pylette import extract_colors
+from pylette.src.extractors.oklab import (
     linear_srgb_to_oklab,
     linear_to_srgb,
     oklab_to_linear_srgb,
     srgb_to_linear,
 )
-from Pylette.types import ExtractionMethod
+from pylette.types import ExtractionMethod
 
 
 class TestOKLabTransforms:


### PR DESCRIPTION
This has been bugging me since I released the first version. I'd like the packagename to be lowercase. We take the opportunity, now that we're working on a new major release. 

- **lowercase pylette package name**
- **update changelog**
